### PR TITLE
turnstile proxy fix, test fix, ProxyInfo import add

### DIFF
--- a/capmonstercloud_client/requests/TurnstileRequest.py
+++ b/capmonstercloud_client/requests/TurnstileRequest.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 from pydantic import Field, validator, model_validator
 from .baseRequestWithProxy import BaseRequestWithProxy
 
@@ -32,6 +32,11 @@ class TurnstileRequest(BaseRequestWithProxy):
                 raise RuntimeError(f'Expect that "htmlPageBase64" will be filled ' \
                     f'when cloudflareTaskType is "cf_clearance"')
         
+        if self.get('proxy') is None:
+            if self.get('cloudflareTaskType') == 'cf_clearance':
+                raise RuntimeError(f'You are working using queries, and you need cf_clearance cookies ' \
+                        f'it is required that you need your proxies.')
+
         if self.get('cloudflareTaskType') == 'token':
             for field in ['pageAction', 'pageData', 'data']:
                 if self.get(field) is None:
@@ -43,9 +48,34 @@ class TurnstileRequest(BaseRequestWithProxy):
                 if self.get('userAgent') is None:
                     raise RuntimeError(f'Expect that userAgent will be filled ' \
                         f'when cloudflareTaskType specified.')
-                    
+          
         return self
     
-    def getTaskDict(self) -> Dict[str, str]:
-        return {k: v for k, v in self.model_dump().items() if v is not None}
+    def getTaskDict(self) -> Dict[str, Union[str, int, bool]]:
+        task = {}
+        task['type'] = self.type
+        task['websiteURL'] = self.websiteURL
+        task['websiteKey'] = self.websiteKey
+        if self.pageAction is not None:
+            task['pageAction'] = self.pageAction
+        if self.data is not None:
+            task['data'] = self.data
+        if self.pageData is not None:
+            task['pageData'] = self.pageData
+        if self.userAgent is not None:
+            task['userAgent'] = self.userAgent
+        if self.cloudflareTaskType is not None:
+            task['cloudflareTaskType'] = self.cloudflareTaskType
+        if self.htmlPageBase64 is not None:
+            task['htmlPageBase64'] = self.htmlPageBase64
+        if self.apiJsUrl is not None:
+            task['apiJsUrl'] = self.apiJsUrl
+        if self.proxy:
+            task['proxyType'] = self.proxy.proxyType
+            task['proxyAddress'] = self.proxy.proxyAddress
+            task['proxyPort'] = self.proxy.proxyPort
+            task['proxyLogin'] = self.proxy.proxyLogin
+            task['proxyPassword'] = self.proxy.proxyPassword
+
+        return task
     

--- a/capmonstercloud_client/requests/__init__.py
+++ b/capmonstercloud_client/requests/__init__.py
@@ -18,6 +18,7 @@ from .AmazonWafRequest import AmazonWafRequest
 from .BinanceTaskRequest import BinanceTaskRequest
 from .ImpervaCustomTaskRequest import ImpervaCustomTaskRequest
 from .RecognitionComplexImageTaskRequest import RecognitionComplexImageTaskRequest
+from .proxy_info import ProxyInfo
 
 
 REQUESTS = ['RecaptchaV2EnterpiseRequest', 'RecaptchaV2Request', 'RecaptchaV3ProxylessRequest', 'RecaptchaComplexImageTaskRequest'

--- a/test/proxy_fields_test.py
+++ b/test/proxy_fields_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from capmonstercloudclient.requests.proxy_info import ProxyInfo
+from capmonstercloudclient.requests import ProxyInfo
         
 
 FIELDS = ['proxyType', 'proxyAddress', 'proxyPort', 'proxyLogin', 'proxyPassword']

--- a/test/turnstile_test.py
+++ b/test/turnstile_test.py
@@ -2,7 +2,7 @@ import unittest
 from copy import deepcopy
 
 from pydantic import ValidationError
-from capmonstercloudclient.requests import TurnstileRequest
+from capmonstercloudclient.requests import TurnstileRequest, ProxyInfo
 
 
 class TurnstileResponseTest(unittest.TestCase):
@@ -34,8 +34,19 @@ class TurnstileResponseTest(unittest.TestCase):
                            'websiteURL', 
                            'websiteKey',
                            'cloudflareTaskType',
-                           'htmlPageBase64']
-        
+                           'htmlPageBase64',
+                           'proxyType',
+                           'proxyAddress',
+                           'proxyPort',
+                           'proxyLogin',
+                           'proxyPassword']
+        proxy = ProxyInfo(
+            proxyType="http",
+            proxyAddress="8.8.8.8",
+            proxyPort=8000,
+            proxyLogin="proxyLoginHere",
+            proxyPassword="proxyPasswordHere"
+        )
         request = TurnstileRequest(websiteKey='0x4AAAAAAADnPIDROrmt1Wwj',
                                             websiteURL='https://nowsecure.nl',
                                             cloudflareTaskType='cf_clearance',
@@ -43,6 +54,7 @@ class TurnstileResponseTest(unittest.TestCase):
                                             userAgent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' \
                                                 'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.' \
                                                 '0.0.0 Safari/537.36',
+                                            proxy=proxy
                                             )
         task_dictionary = request.getTaskDict()
         for f in required_fields:
@@ -70,7 +82,7 @@ class TurnstileResponseTest(unittest.TestCase):
             self.assertTrue(f in list(task_dictionary.keys()), 
                             msg=f'Required captcha input key "{f}" does not include to request.')
             
-    def test_failed_cf_clearance_cases(self):
+    def test_failed_token_cases(self):
         
         base_kwargs = {'websiteKey': '0x4AAAAAAADnPIDROrmt1Wwj',
                        'websiteURL': 'https://nowsecure.nl'}
@@ -88,7 +100,7 @@ class TurnstileResponseTest(unittest.TestCase):
         kwargs_1.update({'userAgent': 'userAgent'})
         TurnstileRequest(**kwargs_1)
     
-    def test_failed_token_cases(self):
+    def test_failed_cf_clearance_cases(self):
         
         base_kwargs = {'websiteKey': '0x4AAAAAAADnPIDROrmt1Wwj',
                        'websiteURL': 'https://nowsecure.nl'}
@@ -100,6 +112,15 @@ class TurnstileResponseTest(unittest.TestCase):
         kwargs_2.update({'htmlPageBase64': 'htmlPageBase64Here'})
         self.assertRaises(RuntimeError, TurnstileRequest, **kwargs_2)
         kwargs_2.update({'userAgent': 'userAgent'})
+        self.assertRaises(RuntimeError, TurnstileRequest, **kwargs_2)
+        proxy = ProxyInfo(
+            proxyType="http",
+            proxyAddress="8.8.8.8",
+            proxyPort=8000,
+            proxyLogin="proxyLoginHere",
+            proxyPassword="proxyPasswordHere"
+        )
+        kwargs_2.update({'proxy': proxy})
         TurnstileRequest(**kwargs_2)
         
 if __name__ == '__main__':


### PR DESCRIPTION
Fixed proxy support for turnstile request, added proxy fields validation for case when `cloudflareTaskType == "cf_clearance"`, fixed tests.
Added import of `ProxyInfo` directly from `capmonstercloud.requests`.

